### PR TITLE
Add a 2 minute session expiry on the mqtt connection

### DIFF
--- a/nodes/project-link.js
+++ b/nodes/project-link.js
@@ -526,8 +526,13 @@ module.exports = function (RED) {
                     /** @type {MQTT.IClientOptions} */
                     const defaultOptions = {
                         protocolVersion: 5,
+                        clean: false,
                         reconnectPeriod: RED.settings.mqttReconnectTime || 5000,
                         properties: {
+                            // Allow the broker to keep the session alive for 2 minutes after
+                            // a disconnect. This ensures short-connectivity blips do not lead to
+                            // inbound message loss.
+                            sessionExpiryInterval: 120,
                             requestResponseInformation: true,
                             requestProblemInformation: true,
                             userProperties: {


### PR DESCRIPTION
Fixes #68 

This updates the project nodes to connect with a non-clean session, meaning session state is not immediately expired when the node disconnects. Alongside this, setting the session expiry to 2 minutes so we don't queue up messages indefinitely.

The choice of a 2 minute session expiry means we'll handle brief connectivity blips without discarding messages.

If the project nodes are disconnected for more than 2 minutes, we'll stop queuing up messages for it (something we didn't do at all previously).

