### PR TITLE
Add 'node-red' keyword

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
         "eslint-config-standard": "^17.0.0",
         "eslint-plugin-html": "7.1.0"
     },
+    "keywords": [ "node-red" ],
     "node-red": {
         "nodes": {
             "project-link": "nodes/project-link.js"


### PR DESCRIPTION
We previously chose not to publish these nodes to the public flow library. However, that makes it harder for users to update their instances when we publish fixes for the nodes.

By adding it to the public catalog, users will be able to update their nodes from within Node-RED.

To facilitate this, we need the package.json file to include the `node-red` keyword - hence this PR.