### PR TITLE
Update the Project Nodes category to "FlowFuse"

### DIFF
--- a/nodes/project-link.html
+++ b/nodes/project-link.html
@@ -297,7 +297,7 @@
     }
 
     RED.nodes.registerType('project link in', {
-        category: 'common',
+        category: 'FlowFuse',
         color: '#87D8CF',
         defaults: {
             name: { value: '_DEFAULT_' },
@@ -341,7 +341,7 @@
     })
 
     RED.nodes.registerType('project link out', {
-        category: 'common',
+        category: 'FlowFuse',
         color: '#87D8CF',
         defaults: {
             name: { value: '_DEFAULT_' },
@@ -404,7 +404,7 @@
     })
 
     RED.nodes.registerType('project link call', {
-        category: 'common',
+        category: 'FlowFuse',
         color: '#87D8CF',
         defaults: {
             name: { value: '' },


### PR DESCRIPTION
## Description

- Move the project nodes to the new "FlowFuse" category (the same as https://github.com/FlowFuse/nr-tables-nodes)

## Related Issue(s)

Closes https://github.com/FlowFuse/node-red/issues/52